### PR TITLE
fix n+1

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -21,7 +21,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers/1
   def show
-    @talks = @speaker.talks.order(date: :desc)
+    @talks = @speaker.talks.includes(:speakers, :event).order(date: :desc)
     @back_path = speakers_path
     set_meta_tags(@speaker)
     # fresh_when(@speaker)


### PR DESCRIPTION
There is an n+1 query triggered by rendering the speakers of each talk because it's not eager loaded in the controller.

| **Before** | **After** |
|------------|-----------|
| ![Before](https://github.com/user-attachments/assets/a573d158-b083-4320-b7cb-7b222bf7cf63) | ![After](https://github.com/user-attachments/assets/05afc230-7d54-41e5-ab3b-ba2311894cc5) |